### PR TITLE
Add setting to enable Nvidia dedicated graphics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
 # MTG Arena Snap
 
 
+## Installation
 
+```bash
+sudo snap install mtg-arena --edge
+# configure here
+mtg-arena
+```
+
+### Configuration
+
+ * If you want to use your dedicated Nvidia graphics card for rendering
+
+   ```bash
+   snap set mtg-arena enable-nvidia-graphics=true
+   ```

--- a/scripts/sommelier
+++ b/scripts/sommelier
@@ -260,6 +260,15 @@ if [ "$SNAP_ARCH" = "amd64" ]; then
 fi
 append_dir LD_LIBRARY_PATH "$LIBGL_DRIVERS_PATH"
 
+# Enable Nvidia dedicated graphics
+# cf. https://forum.snapcraft.io/t/im-building-a-mtg-arena-snap-and-have-some-issues/15826
+if [[ $(snapctl get enable-nvidia-graphics) =~ "true" ]]; then
+  export __NVIDIA_PRIME_RENDER_OFFLOAD=1
+  export __GLX_VENDOR_LIBRARY_NAME=“nvidia”
+  echo "Using Nvidia graphics"
+fi
+# TODO: Do we need something similar for other brands?
+
 # Workaround in snapd for proprietary nVidia drivers mounts the drivers in
 # /var/lib/snapd/lib/gl that needs to be in LD_LIBRARY_PATH
 # Without that OpenGL using apps do not work with the nVidia drivers.

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+# TODO: add validation for config values?
+# For now, accept anything:
+exit 0

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+# Set default values for custom configuration
+snapctl set enable-nvidia-graphics=false


### PR DESCRIPTION
Adds a configuration setting to set up the environment for dedicated Nvidia graphics.

cf. https://forum.snapcraft.io/t/im-building-a-mtg-arena-snap-and-have-some-issues/15826